### PR TITLE
feature: Update config to include @nelson-liu's RSS feed

### DIFF
--- a/blog-aggregator-configs/config2016.ini
+++ b/blog-aggregator-configs/config2016.ini
@@ -86,7 +86,7 @@ faceheight = 100
 name = Terri Oda <br />(PSF Org admin)
 face = 0e17ba44bdb4ef1658b4eb4941ca0382
 
-[https://blog.nelsonliu.me/]
+[http://blog.nelsonliu.me/tag/gsoc/rss/]
 name = Nelson Liu <br />(scikit-learn)
 face = 063261130f2d75e5b33c4866e2121f44
 


### PR DESCRIPTION
I've updated the config to link to an RSS feed of all posts tagged `gsoc`, instead of the main page that it was previously linked to. Let me know if I did anything improperly / you need something else from me.

Thanks for all your hard work Terri!
Nelson Liu
