### PR TITLE
Replace blog link for rootavish with link to feed, handle with name

### DIFF
--- a/blog-aggregator-configs/config2016.ini
+++ b/blog-aggregator-configs/config2016.ini
@@ -246,8 +246,8 @@ face = 1ed4e2118467819d409a79dc017d72ad
 name = Yen <br />(scikit-learn)
 face = d109cfff466633f0a7ed8ead670a8123
 
-[http://rootavish.github.io]
-name = rootavish <br />(ScrapingHub)
+[http://rootavish.github.io/feed.xml]
+name = Avishkar Gupta <br />(ScrapingHub)
 face = 11d7c3adbc41c74a58f2d5ee88c35414
 
 [http://aronbordin.com/scrapy/feed.xml]


### PR DESCRIPTION
Hi,

I had previously provided the link to my blog instead of it's RSS feed, since I wasn't sure on where it would live once I've set up the blog. Providing the correct link to the feed now. Also, I would prefer to use my name instead of my handle, so changed that too.
