### PR TITLE
fix RSS link & provide full name

### DIFF
--- a/blog-aggregator-configs/config2016.ini
+++ b/blog-aggregator-configs/config2016.ini
@@ -90,8 +90,8 @@ face = 0e17ba44bdb4ef1658b4eb4941ca0382
 name = Nelson Liu <br />(scikit-learn)
 face = 063261130f2d75e5b33c4866e2121f44
 
-[http://levijohnwolf.com/rss]
-name = ljwolf <br />(PySAL)
+[http://ljwolf.org/tagged/gsoc/rss]
+name = Levi John Wolf <br />(PySAL)
 face = c3b627a5b772e8efa824b519e0a2910f
 
 [https://scorython.wordpress.com/feed/]


### PR DESCRIPTION
This is a small edit to the aggregator configs to correct my RSS feed URL & name/handle. The current URL stopped working after a domain transfer.
