### PR TITLE
Add neuromancer.sk/recent.atom feed to GSoC 2017.

### DIFF
--- a/blog-aggregator-configs/config2017.ini
+++ b/blog-aggregator-configs/config2017.ini
@@ -139,9 +139,9 @@ face = c25c5d88366036a785765509587b8123
 name = Trailblazer <br />Italian Mars Society
 face = b5f73336fef88726b91a148ace1ee718
 
-[https://neuromancer.sk/]
+[https://neuromancer.sk/recent.atom]
 name = Ján Jančár <br />Mailman
-face = 19a5be234163dba3230af803751fe3a7
+face = c5a328357eda2cf3a9a9b9c48bf5b59c
 
 [https://pradyunsg.github.io/gsoc-2017/feed.xml]
 name = Pradyun Gedam <br />Core Python


### PR DESCRIPTION
Adds my GSoC 2017 blog, well really my only blog, but I will be blogging about GSoC only, to the 2017 config.