### PR TITLE
Added the myhdl mentor and community RSS feeds

### DIFF
--- a/blog-aggregator-configs/config2017.ini
+++ b/blog-aggregator-configs/config2017.ini
@@ -222,3 +222,9 @@ face = 6b0ef86dbc2c5e0a1bc8dd924d05c65a
 [https://raw.githubusercontent.com/python-gsoc/gsoc/master/blog-aggregator-configs/needanrssfeed.xml]
 name = Harshavardhan Srinivas <br />Scrapinghub
 face = baba37d2857dffe3d0576791d5c9ae9a
+
+[https://www.fpgarelated.com/blogs_rss.php?category=GSoC]
+name = Christopher Felton <br />(MyHDL sub-org admin)
+
+[http://discourse.myhdl.org/c/gsoc/gsoc-synopsis.rss]
+name = MyHDL Discourse <br />(MyHDL GSoC on discourse)


### PR DESCRIPTION
Added the myhdl mentor and community RSS feeds particular to GSoC.  We are experimenting with our students posting their blogs to discourse (discourse.myhdl), they will receive more community feedback if the blog posts are in the community forum.