### PR TITLE
Fixed JyNI blog url to be a proper rss feed rather than a plain link

### DIFF
--- a/blog-aggregator-configs/config2017.ini
+++ b/blog-aggregator-configs/config2017.ini
@@ -171,7 +171,7 @@ face = c5b2242a6f17c0518782bfbd68f7b947
 name = aleks_  <br />PySal
 face = 326118cd1e6cbee3474060bec8847ce1
 
-[http://gsoc2017-jyni.blogspot.de]
+[http://gsoc2017-jyni.blogspot.com/feeds/posts/default?alt=rss]
 name = Stefan Richthofer <br />Jython
 face = 3fbe25a423341a396a5f963800a8a3ce
 


### PR DESCRIPTION
I recognized that my initial blog post was not displayed at https://blogs.python-gsoc.org, so I investigated the settings and it appeared that the url was not the rss-feed url, but just a plain link to the blog.